### PR TITLE
Cr dashboard test 2

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -3,6 +3,7 @@ import React, { Component } from "react";
 import {Dashboard} from "./Dashboard"
 import { GraphicsCardProvider } from "./graphics_card/GraphicsCardProvider";
 import { MotherboardProvider } from "./motherboard/MotherboardProvider";
+import { BuildAreaTotalProvider } from "./rig_build/BuildAreaTotalProvider";
 
 export default class ApplicationViews extends Component {
 
@@ -11,9 +12,11 @@ export default class ApplicationViews extends Component {
       <React.Fragment>
         <GraphicsCardProvider>
           <MotherboardProvider>
+            <BuildAreaTotalProvider>
               <Routes>
                 <Route path="/" element={<Dashboard />} />            
               </Routes>
+            </BuildAreaTotalProvider>
           </MotherboardProvider>
         </GraphicsCardProvider>
       </React.Fragment>

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -44,12 +44,18 @@
   border-radius: 5px;
   display: flex;
   flex-direction: column;
+  justify-content: space-evenly;
   align-items: center;
 }
 
 .build-area-totals__list {
   margin: 2em auto;
   text-align: center;
+}
+
+.hardware-cost, .hashrate, .power-consumption {
+  text-align: center;
+  margin: 10px;
 }
 
 /* Save Build btn */
@@ -75,7 +81,7 @@
 }
 
 #save-build {
-  margin-top: 3em;
+  /* margin-top: 1em; */
 }
 
 .ethereum-logo {

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -13,6 +13,10 @@
   margin-top: 230px;
 }
 
+.gpu-library__heading {
+  margin: 5px auto 0 auto;
+}
+
 .build__container {
   display: grid;
   grid-template-rows: 50% 50%;

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -96,7 +96,7 @@
   column-gap: 20px;
   text-align: center;
   margin-right: 45px;
-  margin-bottom: 169px;
+  margin-bottom: 170px;
 }
 
 .revenue, .electricity, .profit {
@@ -104,8 +104,20 @@
   border-radius: 5px;
 }
 
-p, .revenue, .electricity, .profit {
+.revenue h2, .electricity h2, .profit h2 {
+  margin-top: 2px;
+  margin-left: 0.75em;
   text-align: left;
-  padding-left: 20px;
+}
+
+.revenue-metrics, .electricity-metrics, .profit-metrics {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.build-icon {
+  margin-left: 10px;
 }
 

--- a/src/components/Dashboard.css
+++ b/src/components/Dashboard.css
@@ -53,6 +53,10 @@
   text-align: center;
 }
 
+.build-area-totals__list h4 {
+  text-decoration: underline;
+}
+
 .hardware-cost, .hashrate, .power-consumption {
   text-align: center;
   margin: 10px;
@@ -81,7 +85,7 @@
 }
 
 #save-build {
-  /* margin-top: 1em; */
+  margin-bottom: 1em;
 }
 
 .ethereum-logo {

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,11 +1,10 @@
-import React, { useState, useContext, useEffect } from "react";
+import React, { useState, useContext } from "react";
 import "./Dashboard.css";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 import 'bootstrap-icons/font/bootstrap-icons.css';
 import { GraphicsCardList } from "./graphics_card/GraphicsCardList";
 import { MotherboardDropdown } from "./motherboard/MotherboardDropdown";
 import { Dropzone } from "./rig_build/Dropzone";
-import { HardwareCost, Hashrate, PowerConsumption } from "./rig_build/BuildAreaTotals";
 import { GraphicsCardContext } from "./graphics_card/GraphicsCardProvider";
 
 export const Dashboard = () => {
@@ -18,7 +17,7 @@ export const Dashboard = () => {
   // const [hashrate, setHashrate] = useState(0);
   // const [powerConsumption, setPowerConsumption] = useState(0);
 
-  // still needs fixed, but kind working
+  // still needs fixed, but kinda working
   const addToArray = (e) => {
     const newArray = [...gpuArray]
     setGraphicsCards(newArray.concat(graphicsCards.find((gc) => {
@@ -77,9 +76,22 @@ export const Dashboard = () => {
                 }, 0)} W</div>
               </div>
               <div className="save-build">
-                <Link to='/#' >
-                  <button className="ghost" id="save-build"><span>Build!<i class="bi bi-hammer"></i></span></button> 
-                </Link>
+                {/* <Link to='/#' > */}
+                  <button onClick={() => {
+                    let hardwareCost = gpuArray.reduce((previousCard, currentCard) => {
+                      return previousCard + currentCard.cost
+                    }, 0) 
+                    let hashrate = gpuArray.reduce((previousCard, currentCard) => {
+                      return previousCard + currentCard.hashrate
+                    }, 0)
+                    let powerConsumption = gpuArray.reduce((previousCard, currentCard) => {
+                      return previousCard + currentCard.power_consumption
+                    }, 0)
+                    alert(hardwareCost)
+                    alert(hashrate)
+                    alert(powerConsumption)
+                  }} className="ghost" id="save-build"><span>Build!<i class="bi bi-hammer build-icon"></i></span></button> 
+                {/* </Link> */}
               </div>
             </div>
           </div> 
@@ -87,19 +99,34 @@ export const Dashboard = () => {
           {/* Calculations - Revenue, Electricity, Profit */}
           <div className="calculation-metrics__container">
             <div className="revenue">
-              <p>Totals for Day, Month, Year</p>
-              <h1><i class="bi bi-currency-dollar"></i>Revenue</h1>
-              <div className="revenue-metrics"></div>
+              <h2>Revenue</h2>
+              {/* <p>Totals for Day, Week, Month, Year:</p> */}
+              <div className="revenue-metrics">
+                <p> /day</p>
+                <p> /week</p>
+                <p> /month</p>
+                <p> /year</p>
+              </div>
             </div>
             <div className="electricity">
-              <p>Totals for Day, Month, Year</p>
-              <h1><i class="bi bi-lightning-charge"></i>Electricity</h1>
-              <div className="electricity-metrics"></div>
+              <h2>Electricity</h2>
+              {/* <p>Totals for Day, Month, Year:</p> */}
+              <div className="electricity-metrics">
+                <p> /day</p>
+                <p> /week</p>
+                <p> /month</p>
+                <p> /year</p>
+              </div>
             </div>
             <div className="profit">
-              <p>Totals for Day, Month, Year</p>
-              <h1><i class="bi bi-cash-coin"></i>Profit</h1>
-              <div className="profit-metrics"></div>
+              <h2>Profit</h2>
+              {/* <p>Totals for Day, Month, Year:</p> */}
+              <div className="profit-metrics">
+                <p> /day</p>
+                <p> /week</p>
+                <p> /month</p>
+                <p> /year</p>
+              </div>
             </div>
           </div>
         </div>

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -5,11 +5,15 @@ import 'bootstrap-icons/font/bootstrap-icons.css';
 import { GraphicsCardList } from "./graphics_card/GraphicsCardList";
 import { MotherboardDropdown } from "./motherboard/MotherboardDropdown";
 import { Dropzone } from "./rig_build/Dropzone";
+import { HardwareCost, Hashrate, PowerConsumption } from "./rig_build/BuildAreaTotals";
 
 export const Dashboard = () => {
 
 
   const [dropzoneSize,setDropzoneSize] = useState(0);
+  const [hardwareCost, setHardwareCost] = useState(0);
+  const [hashrate, setHashrate] = useState(0);
+  const [powerConsumption, setPowerConsumption] = useState(0);
 
     return (
     <>
@@ -17,7 +21,7 @@ export const Dashboard = () => {
         
         {/* Graphics Card List */}
         <div className="graphics-cards__container">
-          {/* <h1>Graphics Cards</h1> */}
+          <h2 className="gpu-library__heading">Graphics Card Library</h2>
               <div className="graphics-cards__list">
                 <GraphicsCardList/>
               </div>
@@ -43,9 +47,12 @@ export const Dashboard = () => {
             <div className="build-area-totals">
               <img className="ethereum-logo" src={require('../imgs/ethereum-logo-2.png')} alt="Build-A-Rig Logo" />
               <div className="build-area-totals__list">
-                <h2>Hardware Cost</h2>
-                <h2>Hash rate</h2>
-                <h2>Power Consumption</h2>
+                <h4>Hardware Cost</h4>
+                <HardwareCost hardwareCost={hardwareCost}/>
+                <h4>Hash rate</h4>
+                <Hashrate hashrate={hashrate}/>
+                <h4>Power Consumption</h4>
+                <PowerConsumption powerConsumption={powerConsumption}/>
               </div>
               <div className="save-build">
                 <Link to='/#' >

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import "./Dashboard.css";
 import { Link } from "react-router-dom";
 import 'bootstrap-icons/font/bootstrap-icons.css';
@@ -6,14 +6,25 @@ import { GraphicsCardList } from "./graphics_card/GraphicsCardList";
 import { MotherboardDropdown } from "./motherboard/MotherboardDropdown";
 import { Dropzone } from "./rig_build/Dropzone";
 import { HardwareCost, Hashrate, PowerConsumption } from "./rig_build/BuildAreaTotals";
+import { GraphicsCardContext } from "./graphics_card/GraphicsCardProvider";
 
 export const Dashboard = () => {
 
-
+  const {graphicsCards} = useContext(GraphicsCardContext);
   const [dropzoneSize,setDropzoneSize] = useState(0);
-  const [hardwareCost, setHardwareCost] = useState(0);
-  const [hashrate, setHashrate] = useState(0);
-  const [powerConsumption, setPowerConsumption] = useState(0);
+  const [gpuArray, setGraphicsCards] = useState([]);
+
+  // const [hardwareCost, setHardwareCost] = useState(0);
+  // const [hashrate, setHashrate] = useState(0);
+  // const [powerConsumption, setPowerConsumption] = useState(0);
+
+  // still needs fixed, but kind working
+  const addToArray = (e) => {
+    const newArray = [...gpuArray]
+    setGraphicsCards(newArray.concat(graphicsCards.find((gc) => {
+      return gc.id === +e.target.value
+    })))
+  }
 
     return (
     <>
@@ -37,7 +48,7 @@ export const Dashboard = () => {
               <div className="build-area__dropzone">
                 {/* <h1>Build Area</h1> */}
                 <div className="dropzone">
-                  <Dropzone dropzoneSize={dropzoneSize}/>
+                  <Dropzone dropzoneSize={dropzoneSize} addToArray={addToArray}/>
                   {/* area that will display boxes for number of gpu supported by mobo */}
                 </div>
               </div>
@@ -45,14 +56,25 @@ export const Dashboard = () => {
             
             {/* Build Area - Stat Totals */}
             <div className="build-area-totals">
-              <img className="ethereum-logo" src={require('../imgs/ethereum-logo-2.png')} alt="Build-A-Rig Logo" />
+              <div className="crypto-logo">
+                <img className="ethereum-logo" src={require('../imgs/ethereum-logo-2.png')} alt="Build-A-Rig Logo" />
+              </div>
               <div className="build-area-totals__list">
                 <h4>Hardware Cost</h4>
-                <HardwareCost hardwareCost={hardwareCost}/>
+                {/* Hardware Cost Total */}
+                <div className="hardware-cost">${gpuArray.reduce((previousCard, currentCard) => {
+                  return previousCard + currentCard.cost
+                }, 0)}</div>
                 <h4>Hash rate</h4>
-                <Hashrate hashrate={hashrate}/>
+                {/* Hashrate Total */}
+                <div className="hashrate">{gpuArray.reduce((previousCard, currentCard) => {
+                  return previousCard + currentCard.hashrate
+                }, 0)} MH/s</div>
                 <h4>Power Consumption</h4>
-                <PowerConsumption powerConsumption={powerConsumption}/>
+                {/* Power Consumption Total */}
+                <div className="power-consumption">{gpuArray.reduce((previousCard, currentCard) => {
+                  return previousCard + currentCard.power_consumption
+                }, 0)} W</div>
               </div>
               <div className="save-build">
                 <Link to='/#' >

--- a/src/components/Dashboard.js
+++ b/src/components/Dashboard.js
@@ -1,4 +1,4 @@
-import React, { useState, useContext } from "react";
+import React, { useState, useContext, useEffect } from "react";
 import "./Dashboard.css";
 // import { Link } from "react-router-dom";
 import 'bootstrap-icons/font/bootstrap-icons.css';
@@ -6,16 +6,31 @@ import { GraphicsCardList } from "./graphics_card/GraphicsCardList";
 import { MotherboardDropdown } from "./motherboard/MotherboardDropdown";
 import { Dropzone } from "./rig_build/Dropzone";
 import { GraphicsCardContext } from "./graphics_card/GraphicsCardProvider";
+import { BuildAreaTotalContext } from "./rig_build/BuildAreaTotalProvider";
 
 export const Dashboard = () => {
 
+  const {calculations, getCalculations} = useContext(BuildAreaTotalContext); 
+  
   const {graphicsCards} = useContext(GraphicsCardContext);
   const [dropzoneSize,setDropzoneSize] = useState(0);
   const [gpuArray, setGraphicsCards] = useState([]);
 
-  // const [hardwareCost, setHardwareCost] = useState(0);
-  // const [hashrate, setHashrate] = useState(0);
-  // const [powerConsumption, setPowerConsumption] = useState(0);
+  const [cost, setCost] = useState(0);
+  const [hashrate, setHashrate] = useState(0);
+  const [powerConsumption, setPowerConsumption] = useState(0);
+
+  useEffect(() => {
+    setCost(gpuArray.reduce((previousCard, currentCard) => {
+      return previousCard + currentCard.cost
+    }, 0));
+    setHashrate(gpuArray.reduce((previousCard, currentCard) => {
+      return Math.round((previousCard + currentCard.hashrate)*100)/100
+    }, 0));
+    setPowerConsumption(gpuArray.reduce((previousCard, currentCard) => {
+      return previousCard + currentCard.power_consumption
+    }, 0))
+  }, [gpuArray])
 
   // still needs fixed, but kinda working
   const addToArray = (e) => {
@@ -61,19 +76,13 @@ export const Dashboard = () => {
               <div className="build-area-totals__list">
                 <h4>Hardware Cost</h4>
                 {/* Hardware Cost Total */}
-                <div className="hardware-cost">${gpuArray.reduce((previousCard, currentCard) => {
-                  return previousCard + currentCard.cost
-                }, 0)}</div>
+                <div className="hardware-cost">${cost}</div>
                 <h4>Hash rate</h4>
                 {/* Hashrate Total */}
-                <div className="hashrate">{gpuArray.reduce((previousCard, currentCard) => {
-                  return previousCard + currentCard.hashrate
-                }, 0)} MH/s</div>
+                <div className="hashrate">{hashrate} MH/s</div>
                 <h4>Power Consumption</h4>
                 {/* Power Consumption Total */}
-                <div className="power-consumption">{gpuArray.reduce((previousCard, currentCard) => {
-                  return previousCard + currentCard.power_consumption
-                }, 0)} W</div>
+                <div className="power-consumption">{powerConsumption} W</div>
               </div>
               <div className="save-build">
                 {/* <Link to='/#' > */}

--- a/src/components/graphics_card/GraphicsCard.css
+++ b/src/components/graphics_card/GraphicsCard.css
@@ -35,3 +35,8 @@
     font-size: 8px;
 }
 
+.gpu-dropdown {
+    width: 185px;
+    height: 45px;
+}
+

--- a/src/components/graphics_card/GraphicsCard.css
+++ b/src/components/graphics_card/GraphicsCard.css
@@ -40,3 +40,17 @@
     height: 45px;
 }
 
+.modal-specs, .modal-specs-headings {
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.modal-specs-headings h5 {
+  font-size: 16px;
+}
+
+.modal .modal-content{
+  background-color: #80D0C7;
+}
+

--- a/src/components/graphics_card/GraphicsCard.css
+++ b/src/components/graphics_card/GraphicsCard.css
@@ -6,7 +6,7 @@
   justify-content: center;
   align-items: center;
   margin-left: 25px;
-  margin-bottom: 150px;
+  margin-bottom: 140px;
 }
 
 .graphics-cards__list {

--- a/src/components/graphics_card/GraphicsCard.js
+++ b/src/components/graphics_card/GraphicsCard.js
@@ -1,18 +1,84 @@
 import {Badge, Button} from 'react-bootstrap'
+import React, {useState} from "react"
+import { Modal } from 'react-bootstrap';
 
 // Library of available gpu list - will feature hover over modal with additional details
 export const GraphicsCard = ({gpu}) => {
+
+    const [show, setShow] = useState(false);
+
+    const handleClose = () => setShow(false);
+    const handleShow = () => setShow(true);
+
+
+
+
     if (gpu.brand === "Nvidia") {
-        return (
-            <Button variant="dark" className="card-btn">
+           
+        return ( 
+            <>
+            <Button onClick={handleShow} variant="dark" className="card-btn">
             {gpu.name}<Badge className="card-brand" bg="success">{gpu.brand}</Badge>
-            </Button> 
+            </Button>
+
+            <Modal show={show} onHide={handleClose} className="modal">
+                <Modal.Header closeButton>
+                <Modal.Title>{gpu.name}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className="modal-specs-headings">
+                        <h5>Brand</h5>
+                        <h5>Cost</h5>
+                        <h5>Hashrate</h5>
+                        <h5>Power</h5>
+                    </div>
+                    <div className="modal-specs">
+                        <Badge className="modal-brand" bg="success">{gpu.brand}</Badge>
+                        <Badge className="modal-cost" bg="secondary">${gpu.cost}</Badge>
+                        <Badge className="modal-hashrate" bg="info">{gpu.hashrate} MH/s</Badge>
+                        <Badge className="modal-power-consumption" bg="warning">{gpu.power_consumption} W</Badge>
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="dark" onClick={handleClose}>
+                        Close
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+            </>
         )
     } else {
         return (
-            <Button variant="dark" className="card-btn">
+            <>
+            <Button onClick={handleShow} variant="dark" className="card-btn">
             {gpu.name}<Badge className="card-brand" bg="danger">{gpu.brand}</Badge>
-            </Button>  
+            </Button> 
+            
+            <Modal show={show} onHide={handleClose} className="modal">
+                <Modal.Header closeButton>
+                <Modal.Title>{gpu.name}</Modal.Title>
+                </Modal.Header>
+                <Modal.Body>
+                    <div className="modal-specs-headings">
+                        <h5>Brand</h5>
+                        <h5>Cost</h5>
+                        <h5>Hashrate</h5>
+                        <h5>Power</h5>
+                    </div>
+                    <div className="modal-specs">
+                        <Badge className="modal-brand" bg="danger">{gpu.brand}</Badge>
+                        <Badge className="modal-cost" bg="secondary">${gpu.cost}</Badge>
+                        <Badge className="modal-hashrate" bg="info">{gpu.hashrate} MH/s</Badge>
+                        <Badge className="modal-power-consumption" bg="warning">{gpu.power_consumption} W</Badge>
+                    </div>
+                </Modal.Body>
+                <Modal.Footer>
+                    <Button variant="dark" onClick={handleClose}>
+                        Close
+                    </Button>
+                </Modal.Footer>
+            </Modal>
+            </> 
         )
     }
 }

--- a/src/components/graphics_card/GraphicsCard.js
+++ b/src/components/graphics_card/GraphicsCard.js
@@ -1,6 +1,6 @@
 import {Badge, Button} from 'react-bootstrap'
 
-// For click/drag card components under graphics card list container
+// Library of available gpu list - will feature hover over modal with additional details
 export const GraphicsCard = ({gpu}) => {
     if (gpu.brand === "Nvidia") {
         return (
@@ -15,4 +15,12 @@ export const GraphicsCard = ({gpu}) => {
             </Button>  
         )
     }
+}
+
+export const GraphicsCardOption = ({gpu}) => {
+
+        return (
+            <option value={gpu.id}>{gpu.name}</option>
+        )
+    
 }

--- a/src/components/graphics_card/GraphicsCard.js
+++ b/src/components/graphics_card/GraphicsCard.js
@@ -18,6 +18,7 @@ export const GraphicsCard = ({gpu}) => {
 }
 
 export const GraphicsCardOption = ({gpu}) => {
+    
     return (
         <option value={gpu.id}>{gpu.name}</option>
     )

--- a/src/components/graphics_card/GraphicsCard.js
+++ b/src/components/graphics_card/GraphicsCard.js
@@ -18,9 +18,7 @@ export const GraphicsCard = ({gpu}) => {
 }
 
 export const GraphicsCardOption = ({gpu}) => {
-
-        return (
-            <option value={gpu.id}>{gpu.name}</option>
-        )
-    
+    return (
+        <option value={gpu.id}>{gpu.name}</option>
+    )
 }

--- a/src/components/graphics_card/GraphicsCardDropdown.js
+++ b/src/components/graphics_card/GraphicsCardDropdown.js
@@ -1,0 +1,26 @@
+import React, { useContext, useEffect } from "react";
+import { GraphicsCardContext } from "./GraphicsCardProvider";
+import { GraphicsCardOption } from "./GraphicsCard";
+
+export const GraphicsCardDropdown = () => {
+
+  const {graphicsCards, getGraphicsCards} = useContext(GraphicsCardContext);
+    
+  useEffect(() => {
+      getGraphicsCards()
+  }, [])
+
+  return (
+    <>
+      <select
+        class="form-select gpu-dropdown bg-dark text-white border border-dark"
+        aria-label="Default select example"
+      >
+        <option value="0">Pick A GPU</option>
+            {graphicsCards.map((gpu) => {
+                return <GraphicsCardOption key={gpu.id} gpu={gpu} />;
+            })}
+      </select>
+    </>
+  );
+};

--- a/src/components/graphics_card/GraphicsCardDropdown.js
+++ b/src/components/graphics_card/GraphicsCardDropdown.js
@@ -1,24 +1,46 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { GraphicsCardContext } from "./GraphicsCardProvider";
 import { GraphicsCardOption } from "./GraphicsCard";
+import { useParams } from 'react-router-dom';
 
 export const GraphicsCardDropdown = () => {
 
-  const {graphicsCards, getGraphicsCards} = useContext(GraphicsCardContext);
+  const {graphicsCards, getGraphicsCardById} = useContext(GraphicsCardContext);
+
+  const [graphicsCard, setGraphicsCard] = useState({});
+  const [isLoading, setIsLoading] = useState(true);
+
+  const {graphicsCardId} = useParams();
     
   useEffect(() => {
-      getGraphicsCards()
+      if(graphicsCardId) {
+        getGraphicsCardById()
+        .then(graphicsCard => {
+            setGraphicsCard(graphicsCard)
+            setIsLoading(false)
+        })
+      } else {
+          setIsLoading(true)
+      }
+   
   }, [])
+
+  const handleControlledDropdownChange = (e) => {
+      const newGraphicsCard = {...graphicsCard}
+      newGraphicsCard[e.target.id] = e.target.value
+      setGraphicsCard(newGraphicsCard)
+  }
 
   return (
     <>
       <select
+        onChange={handleControlledDropdownChange}
         class="form-select gpu-dropdown bg-dark text-white border border-dark"
         aria-label="Default select example"
       >
         <option value="0">Pick A GPU</option>
             {graphicsCards.map((gpu) => {
-                return <GraphicsCardOption key={gpu.id} gpu={gpu} />;
+                return <GraphicsCardOption key={gpu.id} id={gpu.id} gpu={gpu} />;
             })}
       </select>
     </>

--- a/src/components/graphics_card/GraphicsCardDropdown.js
+++ b/src/components/graphics_card/GraphicsCardDropdown.js
@@ -3,7 +3,7 @@ import { GraphicsCardContext } from "./GraphicsCardProvider";
 import { GraphicsCardOption } from "./GraphicsCard";
 import { useParams } from 'react-router-dom';
 
-export const GraphicsCardDropdown = () => {
+export const GraphicsCardDropdown = ({addToArray}) => {
 
   const {graphicsCards, getGraphicsCardById} = useContext(GraphicsCardContext);
 
@@ -25,16 +25,16 @@ export const GraphicsCardDropdown = () => {
    
   }, [])
 
-  const handleControlledDropdownChange = (e) => {
-      const newGraphicsCard = {...graphicsCard}
-      newGraphicsCard[e.target.id] = e.target.value
-      setGraphicsCard(newGraphicsCard)
-  }
+//   const handleControlledDropdownChange = (e) => {
+//       const newGraphicsCard = {...graphicsCard}
+//       newGraphicsCard[e.target.id] = e.target.value
+//       setGraphicsCard(newGraphicsCard)
+//   }
 
   return (
     <>
       <select
-        onChange={handleControlledDropdownChange}
+        onChange={addToArray}
         class="form-select gpu-dropdown bg-dark text-white border border-dark"
         aria-label="Default select example"
       >

--- a/src/components/graphics_card/GraphicsCardList.js
+++ b/src/components/graphics_card/GraphicsCardList.js
@@ -11,8 +11,6 @@ export const GraphicsCardList = () => {
         getGraphicsCards()
     }, [])
 
-    console.log(graphicsCards)
-
     return (
         <>
         {

--- a/src/components/rig_build/BuildAreaTotalProvider.js
+++ b/src/components/rig_build/BuildAreaTotalProvider.js
@@ -1,0 +1,23 @@
+import React, { createContext, useState } from "react";
+
+export const BuildAreaTotalContext = createContext();
+
+export const BuildAreaTotalProvider =(props) => {
+
+    const [calculations, setCalculations] = useState([])
+    
+    const getCalculations = (hashrate, powerConsumption) => {
+        return fetch(`https://www.coincalculators.io/api?name=ethereum&hashrate=${hashrate}&power=${powerConsumption}&powercost=0.1`)
+        .then(res => res.json())
+        .then(setCalculations)
+    } 
+    
+    return (
+        <BuildAreaTotalContext.Provider value={{
+            calculations, getCalculations
+        }}>
+            {props.children}
+        </BuildAreaTotalContext.Provider>
+    )
+}
+

--- a/src/components/rig_build/BuildAreaTotalProvider.js
+++ b/src/components/rig_build/BuildAreaTotalProvider.js
@@ -6,8 +6,8 @@ export const BuildAreaTotalProvider =(props) => {
 
     const [calculations, setCalculations] = useState([])
     
-    const getCalculations = (hashrate, powerConsumption) => {
-        return fetch(`https://www.coincalculators.io/api?name=ethereum&hashrate=${hashrate}&power=${powerConsumption}&powercost=0.1`)
+    const getCalculations = () => {
+        return fetch(`https://www.coincalculators.io/api?name=ethereum&hashrate=40000000&power=230&powercost=0.1&difficultytime=6`)
         .then(res => res.json())
         .then(setCalculations)
     } 

--- a/src/components/rig_build/BuildAreaTotals.js
+++ b/src/components/rig_build/BuildAreaTotals.js
@@ -1,7 +1,0 @@
-import React from "react";
-
-
-export const BuildAreaTotals =(hardwareCost, hashrate, powerConsumption) => {
-
-}
-

--- a/src/components/rig_build/BuildAreaTotals.js
+++ b/src/components/rig_build/BuildAreaTotals.js
@@ -1,18 +1,7 @@
 import React from "react";
 
 
-export const BuildAreaTotals =({}) => {
+export const BuildAreaTotals =(hardwareCost, hashrate, powerConsumption) => {
 
 }
 
-export const HardwareCost = ({setHardwareCost}) => {
-    return null
-}
-
-export const Hashrate = ({setHashrate}) => {
-    return null
-}
-
-export const PowerConsumption = ({setPowerConsumption}) => {
-    return null
-}

--- a/src/components/rig_build/BuildAreaTotals.js
+++ b/src/components/rig_build/BuildAreaTotals.js
@@ -1,0 +1,18 @@
+import React from "react";
+
+
+export const BuildAreaTotals =({}) => {
+
+}
+
+export const HardwareCost = ({setHardwareCost}) => {
+    return null
+}
+
+export const Hashrate = ({setHashrate}) => {
+    return null
+}
+
+export const PowerConsumption = ({setPowerConsumption}) => {
+    return null
+}

--- a/src/components/rig_build/Dropzone.css
+++ b/src/components/rig_build/Dropzone.css
@@ -12,9 +12,8 @@
 }
 
 .gpu-slot {
-    width: 120px;
-    height: 100px;
-    border: 1px solid black;
+    width: 185px;
+    height: 45px;
     padding-left: 5px;
-    margin: 5px;
+    margin: 15px;
 }

--- a/src/components/rig_build/Dropzone.js
+++ b/src/components/rig_build/Dropzone.js
@@ -3,7 +3,7 @@ import "./Dropzone.css";
 import { GraphicsCardDropdown } from "../graphics_card/GraphicsCardDropdown";
 
 export const Dropzone = ({dropzoneSize}) => {
-    
+
     const motherboards = []
     
     for (let i = 0; i < dropzoneSize; i++) {

--- a/src/components/rig_build/Dropzone.js
+++ b/src/components/rig_build/Dropzone.js
@@ -2,7 +2,7 @@ import React from "react";
 import "./Dropzone.css";
 import { GraphicsCardDropdown } from "../graphics_card/GraphicsCardDropdown";
 
-export const Dropzone = ({dropzoneSize}) => {
+export const Dropzone = ({dropzoneSize, addToArray}) => {
 
     const motherboards = []
     
@@ -14,7 +14,7 @@ export const Dropzone = ({dropzoneSize}) => {
             return (
                 <div className="dropzone gpu-slot">
                     GPU {i}
-                    <GraphicsCardDropdown/>
+                    <GraphicsCardDropdown addToArray={addToArray}/>
                 </div> 
             )  
         }) 

--- a/src/components/rig_build/Dropzone.js
+++ b/src/components/rig_build/Dropzone.js
@@ -1,5 +1,6 @@
 import React from "react";
 import "./Dropzone.css";
+import { GraphicsCardDropdown } from "../graphics_card/GraphicsCardDropdown";
 
 export const Dropzone = ({dropzoneSize}) => {
     
@@ -8,12 +9,13 @@ export const Dropzone = ({dropzoneSize}) => {
     for (let i = 0; i < dropzoneSize; i++) {
         motherboards.push("")  
     }
-    
-    return ( 
-
+     return (
         motherboards.map((mobo,i) => {
             return (
-                <div className="dropzone gpu-slot">GPU {i}</div> 
+                <div className="dropzone gpu-slot">
+                    GPU {i}
+                    <GraphicsCardDropdown/>
+                </div> 
             )  
         }) 
     )


### PR DESCRIPTION
-no longer implementing drag n drop feature for gpu cards to dropzone area
-dropzone area correctly displays number of available gpu slots depending on the motherboard chosen
-gpu slots of dropzone area display dropdowns for all gpu's in db
-modal created to display specs for each gpu button that is clicked on 
-build area totals (cost, hashrate, power consumption) keep a running total as you pick a gpu from the dropzone dropdowns

**dropzone dropdowns has a bug where you can select more than one gpu from a specific dropdown and the build area totals will continue to add those numbers rather than to replace the totals from the previous selected gpu 